### PR TITLE
add new dispatch to handle draggable comments

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@agility/web-studio-sdk",
-  "version": "0.1.0",
+  "version": "1.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@agility/web-studio-sdk",
-      "version": "0.1.0",
+      "version": "1.0.24",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.14.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/web-studio-sdk",
-  "version": "1.0.23",
+  "version": "1.0.24",
   "description": "Standard Development Kit used to enable Web Studio features in Agility CMS",
   "repository": {
     "type": "git",

--- a/src/util/frameEvents.ts
+++ b/src/util/frameEvents.ts
@@ -53,7 +53,14 @@ export interface ISetCommentCoordsEventArgs {
   percentageOffsetY?: number
   uniqueSelector: string
   elementIndex: number
+  isDragEndEvent?: boolean
+  threadId?: string
+  calcFallbackX?: number
+  calcFallbackY?: number
+  originX?: number
+  originY?: number
 }
+
 export interface IDecoratorMapUpdatedEventArgs {
   decoratorMap: TDecoratorMap
 }
@@ -137,12 +144,24 @@ export const dispatchSetCommentCoordsEvent = ({
   percentageOffsetY,
   uniqueSelector,
   elementIndex,
+  isDragEndEvent,
+  threadId,
+  calcFallbackX,
+  calcFallbackY,
+  originX,
+  originY
 }: ISetCommentCoordsEventArgs) => {
-  invokeFrameEvent("set-comment-coords", {
+  invokeFrameEvent(isDragEndEvent? "set-comment-coords-on-drag-end": "set-comment-coords", {
     percentageOffsetX,
     percentageOffsetY,
     uniqueSelector,
     elementIndex,
+    isDragEndEvent,
+    threadId,
+    calcFallbackX,
+    calcFallbackY,
+    originX,
+    originY
   })
 }
 export const dispatchCommentDictionaryUpdatedEvent = ({

--- a/src/util/initializePreview.ts
+++ b/src/util/initializePreview.ts
@@ -122,34 +122,44 @@ export const initializePreview = ({
         break
 
       case "get-comment-coords":
-        const { originX, originY } = arg
+        const { originX, originY, calcFallbackX, calcFallbackY, isDragEndEvent, threadId } = arg
         const element = document.elementFromPoint(originX, originY)
-        if (element) {
-          const deepestEle = getDeepestElementAtCoordinates(
-            element,
-            originX,
-            originY
-          )
-
-          if (deepestEle) {
-            const uniqueSelector = getUniqueSelector(deepestEle)
-            const eleIndex = getSelectorIndex(uniqueSelector, originX, originY)
-            const percentageCoords = getRelativePercentage(
-              deepestEle,
-              originX,
-              originY
-            )
-            arg.uniqueSelector = uniqueSelector
-            dispatchSetCommentCoordsEvent({
-              uniqueSelector,
-              percentageOffsetX: percentageCoords?.percentageX,
-              percentageOffsetY: percentageCoords?.percentageY,
-              elementIndex: eleIndex,
-            })
-          }
-        } else {
+        if (!element){
           console.warn("No element found at the specified coordinates.")
+          return
         }
+
+        const deepestEle = getDeepestElementAtCoordinates(
+          element,
+          originX,
+          originY
+        )
+
+        if (!deepestEle){
+          console.warn("Deepest element could not be found")
+          return
+        }  
+
+        const uniqueSelector = getUniqueSelector(deepestEle)
+        const eleIndex = getSelectorIndex(uniqueSelector, originX, originY)
+        const percentageCoords = getRelativePercentage(
+          deepestEle,
+          originX,
+          originY
+        )
+
+        dispatchSetCommentCoordsEvent({
+          uniqueSelector,
+          percentageOffsetX: percentageCoords?.percentageX,
+          percentageOffsetY: percentageCoords?.percentageY,
+          elementIndex: eleIndex,
+          isDragEndEvent: !!isDragEndEvent,
+          threadId,
+          originX,
+          originY,
+          calcFallbackX,
+          calcFallbackY
+        })
       case "update-comment-dictionary": {
         const { commentDictionary } = arg
         // we've received the comment dictionary from the parent, it will be formatted as an ICommmentDictionary. We need to then map over each entry and go through the same process as the comment-create message event and then return an updated dictionary of type IUpdatedCommentDictionary to the parent with the uniqueSelector, offsetX and offsetY added to each entry

--- a/src/util/invokeFrameEvent.ts
+++ b/src/util/invokeFrameEvent.ts
@@ -12,6 +12,7 @@ export type TFrameEvents =
   | "set-comment-coords"
   | "comment-dictionary-updated"
   | "decorator-map-updated"
+  | "set-comment-coords-on-drag-end"
 
 export const invokeFrameEvent = (
   messageType: TFrameEvents,


### PR DESCRIPTION
The change here is pretty simple:

1. I refactored some code to get rid of nested if blocks
2. If the boolean `isDragEndComment` is true, we will dispatch a different message back to the CMS with some additional metaadata